### PR TITLE
Hotfix: Deal with nimage > 1

### DIFF
--- a/mlacs/utilities/io_abinit.py
+++ b/mlacs/utilities/io_abinit.py
@@ -778,6 +778,15 @@ class AbinitNC:
             forces = np.expand_dims(forces, axis=0)
             stress = np.expand_dims(stress, axis=0)
 
+        # If Abinit nimage > 1, only the result of the first image is kept
+        # XXX CD: in PIMD∕NEB calculations, this will need to be adapted
+        if cell[0].shape != (3, 3):
+            positions = positions[:, 0, ...]
+            cell = cell[:, 0, ...]
+            energy = energy[:, 0, ...]
+            forces = forces[:, 0, ...]
+            stress = stress[:, 0, ...]
+
         nb_confs = len(energy)
         atoms_list = []
         for i in range(nb_confs):


### PR DESCRIPTION
Quick change to adapt the converter {from Abinit's HIST.nc to list of ASE Atoms} to the case of Abinit classical MD, which is typically launched as PIMD with P=1 bead [i.e, imgmov=9 and nimage=1]. Which, in turn, changes the shape of arrays loaded from the HIST.nc.

Complete treatment of nimage > 1 in convert_to_atoms() method would need a full refactoring [won't be doing it r.n.]